### PR TITLE
Upgrade sbt version to newer one

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.4
+sbt.version=1.10.11


### PR DESCRIPTION
### Upgrade sbt version to newer one

With the actual version of **sbt (1.5.4)** we get **error** when loading the project on **Java 21 env**. Here is the error we got : `Class java.lang.UnsupportedOperationException cannot be cast to class xsbti.FullReload`