### PR TITLE
Add missing import to fix bug

### DIFF
--- a/src/main/scala/zionomicon/solutions/02-first-steps-with-zio.scala
+++ b/src/main/scala/zionomicon/solutions/02-first-steps-with-zio.scala
@@ -180,10 +180,12 @@ object FirstStepsWithZIO {
           _    <- cat(args)
         } yield Unit
 
-      def cat(files: Chunk[String]) =
+      def cat(files: Chunk[String]) = {
+        import zio.ChunkCanBuildFrom._
         ZIO.foreach(files) { file =>
           readFileZio(file).flatMap(printLine)
         }
+      }
     }
   }
 


### PR DESCRIPTION
Without this import the `ZIO.foreach` requires an implicit value to **build Chunk[Unit] from Chunk[String]**