### PR TITLE
Fix bug in exercice 10 return type

### DIFF
--- a/src/main/scala/zionomicon/exercises/02-first-steps-with-zio.scala
+++ b/src/main/scala/zionomicon/exercises/02-first-steps-with-zio.scala
@@ -160,8 +160,6 @@ object FirstStepsWithZIO {
    */
   object Exercise10 {
 
-    import java.io.IOException
-
     object Cat extends ZIOAppDefault {
       
       val run =
@@ -170,7 +168,7 @@ object FirstStepsWithZIO {
           _    <- cat(args)
         } yield ()
 
-      def cat(files: Chunk[String]): ZIO[Any, IOException, Unit] =
+      def cat(files: Chunk[String]): ZIO[Any, Throwable, Chunk[Unit]] =
         ???
     }
   }


### PR DESCRIPTION
According to the solution the return type of the cat method should be **`ZIO[Any, Throwable, Chunk[Unit]]`** instead of `ZIO[Any, IOException, Unit]`.