### PR TITLE
Upgrade ZIO version to the latest one

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val zioVersion = "2.0.0"
+val zioVersion = "2.1.17"
 
 libraryDependencies ++= Seq(
   "dev.zio" %% "zio" % zioVersion


### PR DESCRIPTION
In fact, i got an error message when testing the repeatUntil that i need to provide some service Console. To check how to do it, i clicked on the showed link [https://zio.dev/next/datatypes/contextual/](https://zio.dev/next/datatypes/contextual/), but i got a **404 error**.
Then i searched on the source code of the ZIO on the project, and i found that the URL is hardcoded int the `TerminalRendering` classe on the _ZIO 2.0.0_ bundled with this project. But this issue was fixed on the latest version of **ZIO 2.1.17** : https://zio.dev/reference/contextual/