### PR TITLE
Change exercice 20 function name

### DIFF
--- a/src/main/scala/zionomicon/exercises/02-first-steps-with-zio.scala
+++ b/src/main/scala/zionomicon/exercises/02-first-steps-with-zio.scala
@@ -307,7 +307,7 @@ object FirstStepsWithZIO {
    */
   object Exercise20 {
 
-    def doWhile[R, E, A](
+    def doUntil[R, E, A](
       body: ZIO[R, E, A]
     )(condition: A => Boolean): ZIO[R, E, A] =
       ???


### PR DESCRIPTION
Change **exercice 20** function name to be aligned with the description (scaladoc above it).

The description (and also the solution also) specifies that the `effect should be executed in recursion UNTIL the condition returns true`. So it is a **doUntil** instead of _doWhile_. In the later, the description could be WHILE the condition returns true, the effect should recurse.

Otherwise, the description should be updated if the function name can't be changed.

The ZIONOMICON should be also synchronized with this update.