### PR TITLE
docs: Add Zionomicon book cover image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<div style="text-align: center;">
+  <img src="https://zionomicon.com/images/min/book-img.png" alt="Zionomicon Book" width="200" />
+</div>
+
 # Zionomicon Solutions
 
 A comprehensive collection of **exercises and solutions** for learning [ZIO](https://zio.dev/) — a Scala library for asynchronous and concurrent programming.


### PR DESCRIPTION
## Summary
- Adds the official Zionomicon book cover image to the top of the README
- Image is centered for better visual presentation
- Uses the official book image from zionomicon.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)